### PR TITLE
working on resnet50 v1.5

### DIFF
--- a/resblock_testing.ipynb
+++ b/resblock_testing.ipynb
@@ -1,0 +1,106 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "import torch\r\n",
+        "import torch.nn as nn\r\n",
+        "import torch.nn.functional as F\r\n",
+        "\r\n",
+        "# non-square kernels and unequal stride and with padding and dilation\r\n",
+        "m = nn.Conv2d(3, 64, (3, 3), stride=2, padding=(1, 1))\r\n",
+        "input = torch.randn(32, 3, 224, 224)\r\n",
+        "output = m(input)\r\n",
+        "\r\n",
+        "print(output.shape)"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch.Size([32, 64, 112, 112])\n"
+          ]
+        }
+      ],
+      "execution_count": 1,
+      "metadata": {
+        "gather": {
+          "logged": 1619762472653
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from src.resnet50_15 import BottleneckBlock\r\n",
+        "\r\n",
+        "input2 = torch.randn(32, 256, 112, 112)\r\n",
+        "\r\n",
+        "block = BottleneckBlock(64)\r\n",
+        "block2 = BottleneckBlock(128)\r\n",
+        "\r\n",
+        "print(block(input2).shape)"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch.Size([32, 256, 112, 112])\n"
+          ]
+        }
+      ],
+      "execution_count": 2,
+      "metadata": {
+        "collapsed": true,
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        },
+        "gather": {
+          "logged": 1619762479235
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "python3-azureml",
+      "language": "python",
+      "display_name": "Python 3.6 - AzureML"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.6.9",
+      "mimetype": "text/x-python",
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "pygments_lexer": "ipython3",
+      "nbconvert_exporter": "python",
+      "file_extension": ".py"
+    },
+    "kernel_info": {
+      "name": "python3-azureml"
+    },
+    "microsoft": {
+      "host": {
+        "AzureML": {
+          "notebookHasBeenCompleted": true
+        }
+      }
+    },
+    "nteract": {
+      "version": "nteract-front-end@1.0.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/src/resnet50_15.py
+++ b/src/resnet50_15.py
@@ -1,0 +1,39 @@
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class BottleneckBlock(nn.Module):
+    def __init__(self, filters, downsample=False):
+        super().__init__()
+
+        self.conv1 = nn.Conv2d(4 * filters, filters, 1, stride=1)
+        self.bn1 = nn.BatchNorm2d(filters)
+        self.rectifier1 = nn.ReLU()
+
+        # version 1.5 seems to be downsampling here?
+        self.conv2 = nn.Conv2d(filters, filters, 3, stride=2 if downsample else 1, padding=1)
+        self.bn2 = nn.BatchNorm2d(filters)
+        self.rectifier2 = nn.ReLU()
+
+        self.conv3 = nn.Conv2d(filters, 4 * filters, 1, stride=1)
+        self.bn3 = nn.BatchNorm2d(filters * 4)
+        # residual connection here
+        self.rectifier3 = nn.ReLU()
+
+    def forward(self, x):
+        out = x # number of filters must be 4 * filters
+
+        out = self.conv1(out)
+        out = self.bn1(out)
+        out = self.rectifier1(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out = self.rectifier2(out)
+
+        out = self.conv3(out)
+        out = self.bn3(out)
+        out = out + x
+        out = self.rectifier3(out)
+
+        return out


### PR DESCRIPTION
So it seems unzipping the tinyimagenet.zip takes forever, so I started to write some codes

Obviously, it's not working haha

Two roadblocks:

1. Do we have a better way to utilize the datasets? The datasets currently on our AzureML seems to be in an ImageDirectory format, so it can only be consumed by some pre-defined models. What you guys all tried for the exercise of week 1? Just downloading the CIFAR10? Hopefully, there is a much easier way to use the datasets. For now, I will just unzip everything in the host machine.

2. `The difference between v1 and v1.5 is that, in the bottleneck blocks which requires downsampling, v1 has stride = 2 in the first 1x1 convolution, whereas v1.5 has stride = 2 in the 3x3 convolution.` Not sure how it is possible. As you can see in the code, if I downsample the 3x3 layer, the output size will be halved in the middle of the block, yet the input size will still be the same, so the dimension will not match with the input. Do you think we have to downsample both the input and the 3x3 layer? Any opinion from anyone?